### PR TITLE
게시판 api 만들기 - Data rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/board/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/example/board/repository/ArticleCommentRepository.java
@@ -1,8 +1,9 @@
 package com.example.board.repository;
 
-
 import com.example.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/example/board/repository/ArticleRepository.java
+++ b/src/main/java/com/example/board/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.example.board.repository;
 
 import com.example.board.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/test/java/com/example/board/controller/DataRestTest.java
+++ b/src/test/java/com/example/board/controller/DataRestTest.java
@@ -1,0 +1,52 @@
+package com.example.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data rest api test")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mockMvc;
+
+    public DataRestTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @DisplayName("[api]게시글 리스트 단건 조회")
+    @Test
+    void given_whenRequestingArticle_thenReturnsArticlesJsonResponse() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/articles")).andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api]게시글 리스트 -> 댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/articles/1/articleComments")).andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api]게시글 댓글 리스트 조회")
+    @Test
+    void given_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/articleComments")).andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api]게시글 댓글 단건 조회")
+    @Test
+    void given_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/articleComments/1")).andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글 댓글 데이터를 간편하게 스프링 데이터 레스트로 서비스

해당 api의 존재 여부만 체크하게끔 통합테스트 작성